### PR TITLE
include example rsync usage with hss

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ This script can be used by SCP and other things that use SSH as a transport. To 
 scp -S hss host:files/ other_host:location/
 ```
 
+To use it with rsync, use the -e flag:
+
+```
+rsync -e hss files/ host:location/
+```
+
+
 You can alias this for the greater good:
 
 ```
 alias pcs='scp -S hss'
+alias cnysr='rsync -e hss'
 ```
 
 ## Configuration


### PR DESCRIPTION
The README suggests tools other than scp can be used with hss.  Rsync is one of those tools and the docs are remiss for not including it.  An alias is included (`cnycr` which sounds a bit like "see(d)-nicer" :+1:  )

![selfie-1](http://i.imgur.com/whKPbcd.gif)
